### PR TITLE
Add prefix to custom Pyramid config directive

### DIFF
--- a/src/rapids/config.py
+++ b/src/rapids/config.py
@@ -17,7 +17,7 @@ def includeme(config):
     """
     manager = resources.Manager()
     config.registry.registerUtility(manager, resources.IManager)
-    config.add_directive('add_resource', _add_resource)
+    config.add_directive('rapids_add_resource', _add_resource)
     config.set_root_factory(resources.root_factory)
     return
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -79,7 +79,7 @@ class TestFunctional(unittest.TestCase):
     def setUp(self):
         self.config = pyramid.testing.setUp()
         self.config.include('rapids.config')
-        self.config.add_resource(Bar, 'bar{num}', Root)
+        self.config.rapids_add_resource(Bar, 'bar{num}', Root)
         self.config.scan('.')
         self.test_application = webtest.TestApp(self.config.make_wsgi_app())
         return

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -45,7 +45,7 @@ class TestAddResource(unittest.TestCase):
             # pylint: disable=too-few-public-methods
             pass
         try:
-            self.config.add_resource(ValidResource, '', None)
+            self.config.rapids_add_resource(ValidResource, '', None)
         except zope.interface.exceptions.DoesNotImplement as invalid_exception:
             self.fail(invalid_exception)
         return
@@ -59,7 +59,7 @@ class TestAddResource(unittest.TestCase):
             # pylint: disable=too-few-public-methods
             pass
         with self.assertRaises(zope.interface.exceptions.DoesNotImplement):
-            self.config.add_resource(InvalidResource, '', None)
+            self.config.rapids_add_resource(InvalidResource, '', None)
         return
 
 


### PR DESCRIPTION
As it is impossible to know which Pyramid plugins are in use, it is
also impossible to know if configuration directives are installed
and what their names are. It is safer to use a prefix as some kind
of namespace for the names of these directives.